### PR TITLE
implement option to support 4:3 video streams

### DIFF
--- a/octoprint_fullscreen/__init__.py
+++ b/octoprint_fullscreen/__init__.py
@@ -7,7 +7,7 @@ class FullscreenPlugin(octoprint.plugin.SettingsPlugin,
                        octoprint.plugin.TemplatePlugin):
 
 	def get_settings_defaults(self):
-		return dict()
+		return dict(max_height=False)
 
 	def get_assets(self):
 		return dict(
@@ -18,7 +18,8 @@ class FullscreenPlugin(octoprint.plugin.SettingsPlugin,
 
 	def get_template_configs(self):
 		files = [
-			dict(type="generic", template="fullscreen.jinja2", custom_bindings=True)
+			dict(type="generic", template="fullscreen.jinja2", custom_bindings=True),
+			dict(type="settings",custom_bindings=False)
 		]
 
 		return files

--- a/octoprint_fullscreen/static/css/fullscreen.css
+++ b/octoprint_fullscreen/static/css/fullscreen.css
@@ -4,6 +4,17 @@ img.fullscreen {
 	left: 0;
 	width: 100%;
 }
+img.fullscreen_maxheight {
+	outline: 100em solid black;
+	margin: auto;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	height: 100%;
+	width: auto;
+}
 img.fullscreen + #fullscreen-bar {
 	display: block;
 }

--- a/octoprint_fullscreen/static/js/fullscreen.js
+++ b/octoprint_fullscreen/static/js/fullscreen.js
@@ -25,6 +25,10 @@ $(function() {
 		$webcam.on("dblclick", function() {
 			$body.toggleClass('inlineFullscreen');
 			$webcam.toggleClass("inline fullscreen");
+
+			if(self.settings.settings.plugins.fullscreen.max_height()) {
+				$webcam.toggleClass("fullscreen_maxheight");
+			}
 			
 			if(self.printer.isFullscreen()) {
 				$container.toggleFullScreen();

--- a/octoprint_fullscreen/templates/fullscreen_settings.jinja2
+++ b/octoprint_fullscreen/templates/fullscreen_settings.jinja2
@@ -1,0 +1,12 @@
+<form class="form-horizontal">
+
+    <h4>General</h4>
+    <div class="control-group">
+        <label class="control-label">Use full screen height</label>
+        <div class="controls">
+            <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.fullscreen.max_height"> (useful for 4:3 aspect ratio)
+            </label>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Fixes https://github.com/BillyBlaze/OctoPrint-FullScreen/issues/3

You can now select whether to scale the video stream to full screen width or to full screen height. This way, streams with 4:3 aspect ratio show a black border and you get to see the entire picture.