### PR TITLE
Backwards compatible fix for OctoPrint 1.3.6

### DIFF
--- a/octoprint_fullscreen/static/js/fullscreen.js
+++ b/octoprint_fullscreen/static/js/fullscreen.js
@@ -28,7 +28,18 @@ $(function() {
 		self.printer.isFullscreen = ko.observable(false);
 		self.printer.fullscreen = function() {
 			$fullscreenContainer.toggleFullScreen();
-		}
+		};
+
+		self.formatBarTemperatureFullscreen = function(toolName, actual, target) {
+			var output = toolName + ": " + _.sprintf("%.1f&deg;C", actual);
+
+			if (target) {
+				var sign = (target >= actual) ? " \u21D7 " : " \u21D8 ";
+				output += sign + _.sprintf("%.1f&deg;C", target);
+			}
+
+			return output;
+		};
 
 		$webcam.on("dblclick", function() {
 			$body.toggleClass('inlineFullscreen');
@@ -59,14 +70,3 @@ $(function() {
 		["#fullscreen-info"]
 	]);
 });
-
-function formatBarTemperatureFullscreen(toolName, actual, target) {
-	var output = toolName + ": " + _.sprintf("%.1f&deg;C", actual);
-
-	if (target) {
-		var sign = (target >= actual) ? " \u21D7 " : " \u21D8 ";
-		output += sign + _.sprintf("%.1f&deg;C", target);
-	}
-
-	return output;
-};

--- a/octoprint_fullscreen/templates/fullscreen.jinja2
+++ b/octoprint_fullscreen/templates/fullscreen.jinja2
@@ -30,5 +30,5 @@
 </div>
 
 <script type="text/html" id="tempTemplate">
-    <span data-bind="html: formatBarTemperatureFullscreen(name(), actual(), target())"></span>
+    <span data-bind="html: $root.formatBarTemperatureFullscreen(name(), actual(), target())"></span>
 </script>


### PR DESCRIPTION
Instead of declaring the temperature format method implicitly
global (which will cause trouble with 1.3.6) it's now part of the
view model instead.