### PR TITLE
fix: Use the new `#classicwebcam_container`

### DIFF
--- a/octoprint_fullscreen/static/js/fullscreen.js
+++ b/octoprint_fullscreen/static/js/fullscreen.js
@@ -33,13 +33,18 @@ $(function() {
 			var $webcam = $('#webcam_image');
 			var $info = $('#fullscreen-bar');
 	
-			var containerPlaceholder = document.getElementById('webcam') ? '#webcam' : '#webcam_container';
+			var containerPlaceholder = document.querySelector('#webcam,#webcam_container,#classicwebcam_container');
+			if (!containerPlaceholder) {
+				return;
+			}
+
+			var containerPlaceholderSelector = `#${containerPlaceholder.id}`;
 			if ($('.webcam_fixed_ratio').length > 0) {
 				$container = $(containerPlaceholder + ' .webcam_fixed_ratio');
 				$fullscreenContainer = $(containerPlaceholder + ' #webcam_rotator');
 			} else {
 				$container = $(containerPlaceholder + ' #webcam_rotator');
-				$fullscreenContainer = $(containerPlaceholder + ' #webcam_container');
+				$fullscreenContainer = $(containerPlaceholder + ' #classicwebcam_container');
 			}
 
 			var touchtime = 0;

--- a/octoprint_fullscreen/static/js/fullscreen.js
+++ b/octoprint_fullscreen/static/js/fullscreen.js
@@ -40,11 +40,11 @@ $(function() {
 
 			var containerPlaceholderSelector = `#${containerPlaceholder.id}`;
 			if ($('.webcam_fixed_ratio').length > 0) {
-				$container = $(containerPlaceholder + ' .webcam_fixed_ratio');
-				$fullscreenContainer = $(containerPlaceholder + ' #webcam_rotator');
+				$container = $(containerPlaceholderSelector + ' .webcam_fixed_ratio');
+				$fullscreenContainer = $(containerPlaceholderSelector + ' #webcam_rotator');
 			} else {
-				$container = $(containerPlaceholder + ' #webcam_rotator');
-				$fullscreenContainer = $(containerPlaceholder + ' #classicwebcam_container');
+				$container = $(containerPlaceholderSelector + ' #webcam_rotator');
+				$fullscreenContainer = $(containerPlaceholderSelector + ' #classicwebcam_container');
 			}
 
 			var touchtime = 0;


### PR DESCRIPTION
Since https://github.com/OctoPrint/OctoPrint/pull/4628 we need to use `#classicwebcam_container` otherwise all controls and text information provided by this plugin is `display:none`.

Fixes #38 (Landed in OctoPrint v1.9.0)